### PR TITLE
chore(renovate): adopt shared presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,20 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
-  "timezone": "Asia/Taipei",
-  "enabledManagers": ["github-actions", "dockerfile"],
+  "extends": ["local>xlionjuan/renovatebot-presets"],
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["pin", "digest", "pinDigest","major", "minor", "patch"],
-      "automerge": true,
-      "labels": ["dependencies"]
-    },
-    {
+      "description": "Automerge non-major Containerfile base-image updates only after the image build succeeds. Digest updates do not reliably support the shared three-day cooldown.",
       "matchManagers": ["dockerfile"],
-      "matchUpdateTypes": ["pin", "digest", "pinDigest", "minor", "patch"],
+      "matchUpdateTypes": [
+        "pin",
+        "digest",
+        "pinDigest",
+        "minor",
+        "patch"
+      ],
       "automerge": true,
-      "labels": ["base-image"]
+      "addLabels": ["base-image"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- adopt `local>xlionjuan/renovatebot-presets`
- retain CI-gated automerge for non-major Containerfile base-image updates
- add the repository-specific `base-image` label without replacing the shared `dependencies` label

## Validation

- `renovate-config-validator --strict --no-global .github/renovate.json`
- `git diff --check`
- pushed through the special `renovate/reconfigure` validation branch
